### PR TITLE
Add Archlinux as supported OS

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,6 +96,9 @@ class timezone (
         }
       }
     }
+    'Archlinux' : {
+      # nothing else to do for arch
+    }
     default: {
         fail("The OS family ${::osfamily} is not supported by this module.")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -70,6 +70,9 @@
         "11",
         "12"
       ]
+    },
+    {
+      "operatingsystem": "Archlinux"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Archlinux just uses the /etc/localtime file so i just added it to the case to not fail on Arch.
